### PR TITLE
Updated example code to fix issue with URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Copy-paste the following code in your terminal. This was tester on OSX and Linux
 ```bash
 mkdir exakat
 cd exakat
-curl -o exakat.phar https://www.exakat.io/versions/index.php?file=latest
+curl -o exakat.phar "https://www.exakat.io/versions/index.php?file=latest"
 curl -o apache-tinkerpop-gremlin-server-3.4.12-bin.zip https://www.exakat.io/versions/apache-tinkerpop-gremlin-server-3.4.12-bin.zip
 unzip apache-tinkerpop-gremlin-server-3.4.12-bin.zip
 mv apache-tinkerpop-gremlin-server-3.4.12 tinkergraph


### PR DESCRIPTION
URL requires quotations due to presence of question mark. Without this, running the command in the macOS terminal fails. Using quotations around the URL is universal and works on both macOS and Linux.